### PR TITLE
Fix bug in InternalOwner contract

### DIFF
--- a/contracts/access/InternalOwner.sol
+++ b/contracts/access/InternalOwner.sol
@@ -12,7 +12,7 @@ contract InternalOwner {
     event OwnershipTransferred(address previousOwner, address newOwner);
 
     modifier onlyOwner() {
-        require(msg.sender == owner, _ErrorCodes.NOT_OWNER);
+        require(msg.sender == owner && msg.sender.value != 0, _ErrorCodes.NOT_OWNER);
         _;
     }
 


### PR DESCRIPTION
Bug was in `onlyOwner` modifier
It appears after calling `renounceOwnership` and cause that any external message could pass `onlyOwner ` check